### PR TITLE
fixing landmarks errors (#2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CGE"
 uuid = "f7ff1d1e-e254-4b26-babe-fc3421add060"
 authors = ["KrainskiL <lukasz.krainski123@gmail.com>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"


### PR DESCRIPTION
Landmarks are truncated to **unique no. embeddings** instead of no. rows in embedding file. Additional tweaks introduced in diameter and size landmark generation methods to prevent empty cluster creation. 

Output of previously erroneous executions:

```shell
(base) PS C:\CGE.jl\example> julia CGE_CLI.jl -g karate.0.edgelist -c karate.ecg -e karate.sdne.embedding -l 200 -f 5
┌ Warning: Requested number of clusters larger than unique no. embeddings. Truncating to 29 landmarks.
└ @ CGE C:\CGE.jl\src\landmarks.jl:372
[6.25, 0.010762934583196881, 0.0004941797726451878, 0.021031689393748575]
(base) PS C:\CGE.jl\example> julia CGE_CLI.jl -g karate.0.edgelist -c karate.ecg -e karate.sdne.embedding -l 200 -f 5 -m rss2
┌ Warning: Requested number of clusters larger than unique no. embeddings. Truncating to 29 landmarks.
└ @ CGE C:\CGE.jl\src\landmarks.jl:372
[6.25, 0.010762934583196876, 0.0004941797726452269, 0.021031689393748526]
(base) PS C:\CGE.jl\example> julia CGE_CLI.jl -g karate.0.edgelist -c karate.ecg -e karate.sdne.embedding -l 200 -f 5 -m size
┌ Warning: Requested number of clusters larger than unique no. embeddings. Truncating to 29 landmarks.
└ @ CGE C:\CGE.jl\src\landmarks.jl:372
[6.75, 0.00945988018245218, 0.0004786591629020592, 0.0184411012020023]
(base) PS C:\CGE.jl\example> julia CGE_CLI.jl -g karate.0.edgelist -c karate.ecg -e karate.sdne.embedding -l 200 -f 5 -m diameter
┌ Warning: Requested number of clusters larger than unique no. embeddings. Truncating to 29 landmarks.
└ @ CGE C:\CGE.jl\src\landmarks.jl:372
[6.25, 0.010762934583196854, 0.0004941797726452158, 0.02103168939374849]
```
@bkamins Please have a look at the new code